### PR TITLE
Provide default values for Passenger parameters

### DIFF
--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -43,10 +43,10 @@ class puppet::passenger(
   $conf_dir,
   $dns_alt_names,
   $config_addon = '',
-  $passenger_max_pool_size,
-  $passenger_high_performance,
-  $passenger_max_requests,
-  $passenger_stat_throttle_rate,
+  $passenger_max_pool_size = 6,
+  $passenger_high_performance = 'off',
+  $passenger_max_requests = 0,
+  $passenger_stat_throttle_rate = 10,
 ){
   include apache
   include puppet::params


### PR DESCRIPTION
Provide default values for Passenger parameters since `undef` can't be passed through to `apache::mod::passenger`. These values are taken from https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html